### PR TITLE
Add cross-dimensional rings transport support for mounted entities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -52,7 +52,7 @@ mod_name=JSG: Rings and Transporters
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=1.0.0.0
+mod_version=1.0.0.0-sini-1.0.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/dev/tauri/jsgtransporters/common/blockentity/rings/RingsAbstractBE.java
+++ b/src/main/java/dev/tauri/jsgtransporters/common/blockentity/rings/RingsAbstractBE.java
@@ -910,12 +910,24 @@ public abstract class RingsAbstractBE extends BlockEntity implements ILinkable<A
         var maxPos = new BlockPos(1, getVerticalOffset() + index, 1).offset(getBlockPos());
         var poses = StreamSupport.stream(BlockPos.betweenClosed(minPos, maxPos).spliterator(), false);
         var entities = level.getEntities(null, new JSGAxisAlignedBB(minPos.getCenter(), maxPos.getCenter()).grow(0.5, 0.5, 0.5));
-        for (var e : entities) {
-            if (ignoredEntities.contains(e)) continue;
-            var energyToTransport = energyToOperate.getEnergyForTransport(e);
+
+        boolean crossDimensional = level.dimension() != this.targetRings.dimension;
+
+        for (var entity : entities) {
+            if (ignoredEntities.contains(entity)) continue;
+
+            // During cross-dimensional transport, only process root entities.
+            // Passengers are transferred together with their vehicle/entity hierarchy.
+            if (crossDimensional && entity.isPassenger()) continue;
+
+            var energyToTransport = energyToOperate.getEnergyForTransport(entity);
             if (getEnergyStored() < energyToTransport) continue;
-            targetRings.ignoredEntities.add(e);
-            TeleportHelper.teleportEntity(e, ringsPos, this.targetRings);
+
+            Entity teleportedEntity = TeleportHelper.teleportEntity(entity, ringsPos, this.targetRings);
+            if (teleportedEntity != null) {
+                markIgnoredRecursive(targetRings, teleportedEntity);
+            }
+
             getEnergyStorage().extractEnergy(energyToTransport, false);
         }
 
@@ -927,10 +939,21 @@ public abstract class RingsAbstractBE extends BlockEntity implements ILinkable<A
                     var relPos = p.subtract(getBlockPos().above(getVerticalOffset()));
                     return Map.entry(p, targetRings.getBlockPos().above(targetRings.getVerticalOffset()).offset(relPos));
                 })
-                .filter(pp -> !level.getBlockState(pp.getKey()).is(TagsRegistry.UNTRANSPORTABLE_BLOCK) && !targetRings.level.getBlockState(pp.getValue()).is(TagsRegistry.UNTRANSPORTABLE_BLOCK));
+                .filter(pp -> !level.getBlockState(pp.getKey()).is(TagsRegistry.UNTRANSPORTABLE_BLOCK)
+                        && !targetRings.level.getBlockState(pp.getValue()).is(TagsRegistry.UNTRANSPORTABLE_BLOCK));
+
         TeleportHelper.teleportBlocks(filteredPoses, this, targetRings, pistonHeads);
+
         if (isLast) {
             pistonHeads.forEach(pp -> pp.placeOrAdd(null));
+        }
+    }
+
+    private static void markIgnoredRecursive(RingsAbstractBE rings, Entity entity) {
+        rings.ignoredEntities.add(entity);
+
+        for (Entity passenger : entity.getPassengers()) {
+            markIgnoredRecursive(rings, passenger);
         }
     }
 

--- a/src/main/java/dev/tauri/jsgtransporters/common/helpers/RingsTeleporter.java
+++ b/src/main/java/dev/tauri/jsgtransporters/common/helpers/RingsTeleporter.java
@@ -8,28 +8,27 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.util.ITeleporter;
 import org.joml.Vector3d;
 
-import javax.annotation.Nullable;
-import java.util.List;
 import java.util.function.Function;
 
-public record RingsTeleporter(Vector3d posFinal, float newYaw, @Nullable List<Entity> passengers) implements ITeleporter {
+public record RingsTeleporter(Vector3d posFinal, float newYaw) implements ITeleporter {
 
     @Override
     public PortalInfo getPortalInfo(Entity entity, ServerLevel destWorld, Function<ServerLevel, PortalInfo> defaultPortalInfo) {
-        return new PortalInfo(new Vec3(posFinal.x(), posFinal.y(), posFinal.z()), new Vec3(0, 0, 0), newYaw, entity.getXRot());
+        return new PortalInfo(
+                new Vec3(posFinal.x(), posFinal.y(), posFinal.z()),
+                Vec3.ZERO,
+                newYaw,
+                entity.getXRot()
+        );
     }
 
     @Override
     public Entity placeEntity(Entity entity, ServerLevel currentWorld, ServerLevel destWorld, float yaw, Function<Boolean, Entity> repositionEntity) {
-        Entity e = repositionEntity.apply(false);
-        if (e == null) return null;
-        TeleportHelper.setRotationAndPosition(e, newYaw, posFinal);
-        if (passengers != null) {
-            for (Entity passenger : passengers) {
-                passenger.startRiding(e);
-            }
-        }
-        return e;
+        Entity placedEntity = repositionEntity.apply(false);
+        if (placedEntity == null) return null;
+
+        TeleportHelper.setRotationAndPosition(placedEntity, newYaw, posFinal);
+        return placedEntity;
     }
 
     @Override

--- a/src/main/java/dev/tauri/jsgtransporters/common/helpers/TeleportHelper.java
+++ b/src/main/java/dev/tauri/jsgtransporters/common/helpers/TeleportHelper.java
@@ -34,24 +34,121 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.EntityType;
+
 public class TeleportHelper {
-    public static void teleportEntity(Entity entity, RingsPos sourceRings, RingsPos targetRings) {
+    public static Entity teleportEntity(Entity entity, RingsPos sourceRings, RingsPos targetRings) {
         Level world = entity.level();
         ResourceKey<Level> sourceDim = world.dimension();
 
         var offset = entity.position()
                 .subtract(sourceRings.ringsPos.getCenter().add(0, sourceRings.getBlockEntity().getVerticalOffset(), 0));
-        var tPos = targetRings.ringsPos.getCenter().add(0, targetRings.getBlockEntity().getVerticalOffset(), 0).add(offset);
+        var targetPos = targetRings.ringsPos.getCenter()
+                .add(0, targetRings.getBlockEntity().getVerticalOffset(), 0)
+                .add(offset);
 
         if (sourceDim == targetRings.dimension) {
-            setRotationAndPosition(entity, entity.getYHeadRot(), new Vector3d(tPos.x, tPos.y, tPos.z));
+            setRotationAndPosition(entity, entity.getYHeadRot(), new Vector3d(targetPos.x, targetPos.y, targetPos.z));
+            return entity;
         } else {
-            //if (!fireTravelToDimEvent(entity, targetRings.dimension))
-            //    return;
+            // Keep players on the default dimension change path.
+            if (entity instanceof ServerPlayer player) {
+                return player.changeDimension(
+                        Objects.requireNonNull(Objects.requireNonNull(entity.getServer()).getLevel(targetRings.dimension)),
+                        new RingsTeleporter(new Vector3d(targetPos.x, targetPos.y, targetPos.z), entity.getYRot()));
+            }
 
-            entity.changeDimension(
-                    Objects.requireNonNull(Objects.requireNonNull(entity.getServer()).getLevel(targetRings.dimension)),
-                    new RingsTeleporter(new Vector3d(tPos.x, tPos.y, tPos.z), entity.getYRot(), null));
+            // Rebuild non-player entity trees manually to preserve mounted passengers across dimensions.
+            return manualTeleportEntityTree(entity, targetRings, new Vector3d(targetPos.x, targetPos.y, targetPos.z));
+        }
+    }
+
+    private static Entity manualTeleportEntityTree(Entity entity, RingsPos targetRings, Vector3d targetPos) {
+        var server = entity.getServer();
+        if (server == null) return null;
+
+        ServerLevel targetLevel = server.getLevel(targetRings.dimension);
+        if (targetLevel == null) return null;
+
+        // Detach passengers before recreating the root entity in the target dimension.
+        var passengers = new ArrayList<>(entity.getPassengers());
+        for (Entity passenger : passengers) {
+            passenger.stopRiding();
+        }
+
+        Entity teleportedRoot = manualTeleportSingle(entity, targetLevel, targetPos);
+        if (teleportedRoot == null) return null;
+
+        // Recreate passengers recursively and attach them back to the teleported root.
+        for (Entity passenger : passengers) {
+            Entity teleportedPassenger = teleportPassenger(passenger, targetRings, targetPos);
+            if (teleportedPassenger != null) {
+                teleportedPassenger.startRiding(teleportedRoot, true);
+            }
+        }
+
+        return teleportedRoot;
+    }
+
+    private static Entity teleportPassenger(Entity passenger, RingsPos targetRings, Vector3d targetPos) {
+        if (passenger instanceof ServerPlayer player) {
+            var server = player.getServer();
+            if (server == null) return null;
+
+            ServerLevel targetLevel = server.getLevel(targetRings.dimension);
+            if (targetLevel == null) return null;
+
+            return player.changeDimension(
+                    targetLevel,
+                    new RingsTeleporter(targetPos, player.getYRot()));
+        }
+
+        return manualTeleportEntityTree(passenger, targetRings, targetPos);
+    }
+
+    private static Entity manualTeleportSingle(Entity entity, ServerLevel targetLevel, Vector3d targetPos) {
+        CompoundTag tag = new CompoundTag();
+        if (!entity.save(tag)) return null;
+
+        // Passengers are rebuilt manually to avoid duplicating nested entity trees.
+        tag.remove("Passengers");
+
+        // Remove UUID data before spawning a new entity instance.
+        stripUuidsRecursive(tag);
+
+        Entity spawnedEntity = EntityType.loadEntityRecursive(tag, targetLevel, loaded -> {
+            loaded.moveTo(targetPos.x, targetPos.y, targetPos.z, entity.getYRot(), entity.getXRot());
+            loaded.setDeltaMovement(entity.getDeltaMovement());
+            loaded.setYHeadRot(entity.getYHeadRot());
+            loaded.fallDistance = 0;
+            return loaded;
+        });
+
+        if (spawnedEntity == null) return null;
+
+        targetLevel.addDuringTeleport(spawnedEntity);
+
+        // Remove only the current source entity. Passengers are handled separately.
+        entity.remove(Entity.RemovalReason.CHANGED_DIMENSION);
+
+        return spawnedEntity;
+    }
+
+    private static void stripUuidsRecursive(CompoundTag tag) {
+        tag.remove("UUID");
+        tag.remove("UUIDMost");
+        tag.remove("UUIDLeast");
+
+        if (tag.contains("Passengers", Tag.TAG_LIST)) {
+            ListTag passengers = tag.getList("Passengers", Tag.TAG_COMPOUND);
+            for (int i = 0; i < passengers.size(); i++) {
+                stripUuidsRecursive(passengers.getCompound(i));
+            }
         }
     }
 


### PR DESCRIPTION
- Support transport of entities with passengers (boats, minecarts)
- Prevent double-processing by only teleporting root entities
- Rebuild entity trees manually for non-player cross-dim transport
- Keep vanilla player teleport behavior
- Remove passenger handling from RingsTeleporter